### PR TITLE
Fix read_cma

### DIFF
--- a/ocaml-compiler-libs.opam
+++ b/ocaml-compiler-libs.opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "5.2.0"}
   "dune" {>= "1.5.1"}
 ]
 synopsis: """OCaml compiler libraries repackaged"""

--- a/src/read_cma/read_cma.ml
+++ b/src/read_cma/read_cma.ml
@@ -1,5 +1,7 @@
 open StdLabels
 
+let compunit_name Cmo_format.{ cu_name = Compunit name ; _ } = name
+
 let units fn =
   (* The cma format is documented in typing/cmo_format.mli in the compiler sources *)
   let ic = open_in_bin fn in
@@ -11,5 +13,5 @@ let units fn =
   let toc = (input_value ic : Cmo_format.library) in
   close_in ic;
 
-  List.map toc.lib_units ~f:(fun cu -> cu.Cmo_format.cu_name)
+  List.map toc.lib_units ~f:compunit_name
   |> List.sort ~cmp:String.compare


### PR DESCRIPTION
A quick fix to compile ppxlib with the ocaml trunk, as the `Cmo_format.cu_name` is now a newtype since https://github.com/ocaml/ocaml/pull/12031

https://github.com/ocaml/ocaml/blob/7810957dec3137ad386bd529c32e61659102398c/file_formats/cmo_format.mli#L20-L21